### PR TITLE
I updated the install script to do everything and not leave out steps.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,8 +14,7 @@ chmod +x /lib/cpapiserver/CloudPanelApi
 systemctl daemon-reload
 systemctl enable --now cpapiserver
 service cpapiserver start
-API_KEY=0aec0551-e311-4ce0-8d9a-06751ac01234
-echo Default API Key: $API_KEY
-echo Make your API key unique using this cmd: API_KEY=Your-Random-String-Here-1234
+API_KEY=`openssl rand -hex 28`
+echo Your new random API Key: $API_KEY
 echo Be sure to open port 9999 on your CloudPanel firewall too
 echo Ok, cpapiserver service should be installed and running!

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-﻿#! /bin/bash
+#!/bin/bash
 
 echo "Installing cloud panel api server"
 
@@ -12,3 +12,10 @@ curl -L -o /etc/systemd/system/cpapiserver.service https://raw.githubusercontent
 chmod 664 /etc/systemd/system/cpapiserver.service
 chmod +x /lib/cpapiserver/CloudPanelApi
 systemctl daemon-reload
+systemctl enable --now cpapiserver
+service cpapiserver start
+API_KEY=0aec0551-e311-4ce0-8d9a-06751ac01234
+echo Default API Key: $API_KEY
+echo Make your API key unique using this cmd: API_KEY=Your-Random-String-Here-1234
+echo Be sure to open port 9999 on your CloudPanel firewall too
+echo Ok, cpapiserver service should be installed and running!


### PR DESCRIPTION
I struggled through getting this working, so hope this helps clarify things for others. It works great now, very happy.

(I wish there was a way to create WordPress sites but the clpcli doesn't yet support that, so must be done manually... use the API to create a PHP site using WordPress vhost template, create DB, then manually install WP files and edit wp-config.php)